### PR TITLE
Update clause_3_references.adoc

### DIFF
--- a/standard/clause_3_references.adoc
+++ b/standard/clause_3_references.adoc
@@ -1,6 +1,6 @@
 [[references-section]]
 == References
-The following normative documents contain provisions that, through reference in this text, constitute provisions of OGC TBD. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. However, parties to agreements based on this part of OGC TBD are encouraged to investigate the possibility of applying the most recent editions of the normative documents indicated below. For undated references, the latest edition of the normative document referred to applies.
+The following normative documents contain provisions that, through reference in this text, constitute provisions of OGC. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. However, users are encouraged to investigate the possibility of applying the most recent editions of the normative documents indicated below. For undated references, the latest edition of the normative document referred to applies.
 
 * [[rfc2045,RFC 2045]] IETF: RFC 2045 & 2046, Multipurpose Internet Mail Extensions (MIME). (November 1996),
 * [[rfc3986,RFC 3986]] IETF: RFC 3986, Uniform Resource Identifier (URI): Generic Syntax. (January 2005)


### PR DESCRIPTION
Slightly simpler wording, and remove "TBD" twice.

Part of unused https://github.com/opengeospatial/CityGML-3.0Encodings/pull/76