### PR TITLE
update github links

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -1,6 +1,6 @@
 # GML Encoding Standard for CityGML 3.0
 
-Draft versions of this standard are available as [PDF](https://github.com/opengeospatial/CityGML-3.0Encodings/blob/master/CityGML/21-006.pdf) and [HTML](https://github.com/opengeospatial/CityGML-3.0Encodings/blob/master/CityGML/21-006.html) documents.
+Draft versions of this standard are available as [PDF](https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/standard/21-006.pdf) and [HTML](https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/standard/21-006.html) documents.
 
 ## Content
 

--- a/standard/annex-examples-address.adoc
+++ b/standard/annex-examples-address.adoc
@@ -8,7 +8,7 @@ An _Address_ is modeled with two properties:
 - An optional _multiPoint_ property containing a _gml:MultiPoint_ for specifying the 2D or 3D position of the address. 
 - A _xalAddress_ property containing a _xAL:Address_ type from the OASIS CIQ TC extensible Address Language standard (xAL).
 
-The CityGML datasets presented here are available under https://github.com/opengeospatial/CityGML-3.0Encodings/tree/master/CityGML/Examples/Building, additional examples are also available on the OASIS documentation repository http://docs.oasis-open.org/ciq/v3.0/cs02/xsd/default/examples/xAL/.
+The CityGML datasets presented here are available under https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/resources/examples/Building, additional examples are also available on the OASIS documentation repository http://docs.oasis-open.org/ciq/v3.0/cs02/xsd/default/examples/xAL/.
 
 *Example 1: Structured address and multipoint*
 

--- a/standard/annex-examples-pointcloud.adoc
+++ b/standard/annex-examples-pointcloud.adoc
@@ -3,7 +3,7 @@
 
 The PointCloud module allows for representing the geometries of city objects by 3D point clouds in three different options, which are illustrated in the following.
 
-The CityGML and LAZ data sets presented here are available under https://github.com/opengeospatial/CityGML-3.0Encodings/tree/master/CityGML/Examples/PointCloud/Real-world%20examples/CityGML_3.0_buildings_with_point_cloud_representation.
+The CityGML and LAZ data sets presented here are available under https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/resources/examples/PointCloud/Real-world%20examples/CityGML_3.0_buildings.
 
 *Option 1: Inline representation*
 

--- a/standard/annex-examples.adoc
+++ b/standard/annex-examples.adoc
@@ -4,7 +4,7 @@
 [[annex-examples]]
 == Examples (Informative)
 
-Various CityGML 3.0 test data sets are available on GitHub for each CityGML module, including those test data sets presented in this chapter: https://github.com/opengeospatial/CityGML-3.0Encodings/tree/master/CityGML/Examples.
+Various CityGML 3.0 test data sets are available on GitHub for each CityGML module, including those test data sets presented in this chapter: https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/resources/examples.
 
 The examples and information provided in this chapter focus on the new CityGML 3.0 modules Dynamizer, PointCloud, and Versioning. In addition, some examples for the description of addresses using xAL 3 are provided (this is a change from CityGML 2.0, where xAL 2 was used). Since the ADE mechanism has been improved in CityGML 3.0, examples for the use of the revised ADE mechanism are provided as well.
 

--- a/standard/clause_6_0_Global.adoc
+++ b/standard/clause_6_0_Global.adoc
@@ -210,8 +210,7 @@ image::images/Example_SimpleBuilding.png[width="25%"]
 
 The building (=space) in <<figure-example-simple-building>> is modelled in LOD2 as Solid geometry and is bounded by four WallSurfaces, one RoofSurface, and one GroundSurface (=space boundaries). All space boundaries are modelled as Polygon geometries. The Solid geometry of the building references the Polygon geometries using XLink. This example refers to Requirement <<req_global_referencinggeometries2,/req/global/referencinggeometries2>>.
 
-The GML file is available here:
-https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/1_SimpleBuilding
+The GML file is available on the https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/1_SimpleBuilding[CityGML 3.0 Encodings Github].
 
 The Building from the GML file is illustrated in the object diagram in <<figure-uml-simple-building>>. The XLink references between the Solid geometry and the Polygon geometries are highlighted in red.
 
@@ -229,8 +228,7 @@ The building (=space) in <<figure-example-building-with-roof-overhangs>> is mode
 
 The RoofSurface contains four Polygon geometries. Two of these Polygons are roof overhangs (i.e. dangling surfaces), and, thus, are not referenced by the Solid geometry of the building, as they would render the solid invalid if referenced. For this reason, an additional MultiSurface geometry is added to the building that references the dangling surfaces. In accordance with Requirement <<req_global_referencinggeometries2,/req/global/referencinggeometries2>> this MultiSurface geometry is optional. It is added to the building to provide additional information, but it is not mandatory to add this geometry.
 
-The GML file is available here:
-https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/2_SimpleBuilding_Roof_Overhangs
+The GML file is available on the https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/2_SimpleBuilding_Roof_Overhangs[CityGML 3.0 Encodings Github].
 
 The Building from the GML file is illustrated in the object diagram in <<figure-uml-building-with-roof-overhangs>>. The XLink references between the Solid geometry and the Polygon geometries are highlighted in red, the XLink references between the MultiSurface geometry and the dangling surfaces in blue.
 
@@ -248,8 +246,7 @@ The building (=space) in <<figure-example-building-with-building-installation>> 
 
 The space boundaries of the building and of the building installation are all modelled as Polygon geometries. The Solid geometry of the building references those Polygon geometries that represent the space boundaries of the building space using XLink. The MultiSurface geometry of the building installation references those Polygon geometries that represent the space boundaries of the building installation using XLink. In addition, the Solid geometry may also reference the Polygon geometries that represent the space boundaries of the building installation using XLink. These references to the geometries of a nested space are optional, in accordance with Requirement <<req_global_referencinggeometries2,/req/global/referencinggeometries2>> it is also allowed to not reference these geometries.
 
-The GML file is available here:
-https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/3_Building_With_Nested_Features
+The GML file is available on the https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/3_Building_With_Nested_Features[CityGML 3.0 Encodings Github].
 
 The Building from the GML file is illustrated in the object diagram in <<figure-uml-building-with-building-installation>>. The XLink references from the building to the space boundaries of the building are highlighted in red, whereas those to the space boundaries of the building installation are highlighted in blue.
 
@@ -271,8 +268,7 @@ The two buildings (=top-level features) in <<figure-example-two-buildings>> are 
 
 To express that the WallSurfaces of the two buildings share the Polygon geometry, the WallSurfaces reference each other using a CityObjectRelation with the relation type “shared”. Both WallSurfaces contain the Polygon geometry themselves, the second WallSurface, however, in reverse order.
 
-The GML file is available here:
-https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/4_Cross-Top-Level-XLink
+The GML file is available on the https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/4_Cross-Top-Level-XLink[CityGML 3.0 Encodings Github].
 
 The Buildings from the GML file are illustrated in the object diagram in <<figure-uml-two-buildings>>. The CityObjectRelation is highlighted in red.
 
@@ -290,8 +286,7 @@ A Road and a Bridge (=top-level features) are modelled in LOD2, as is shown in <
 
 To express that the RoofSurfaces share MultiSurface geometries with two TrafficAreas, they reference each other using CityObjectRelations with the relation type “shared”.
 
-The GML file is available here:
-https://github.com/opengeospatial/CityGML-3.0Encodings/blob/master/CityGML/Examples/Transportation/Basic%20examples/Road_over_Bridge_CityGML3.0_LOD2_with_CityObjectRelations.gml
+The GML file is available on the https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/resources/examples/Transportation/Basic%20examples/Road_over_Bridge_CityGML3.0_LOD2_with_CityObjectRelations.gml[CityGML 3.0 Encodings Github].
 
 The Road and Bridge from the GML file are illustrated in the object diagram in <<figure-uml-road-over-bridge>>. The CityObjectRelations are highlighted in red.
 
@@ -309,8 +304,7 @@ The parking garage in <<figure-example-parking-garage>> is modelled in LOD2 as a
 
 To express the sharing of MultiSurface geometries between the Roof-/WallSurfaces and the Sections/TrafficAreas, they reference each other using CityObjectRelations with the relation type “shared”.
 
-The GML file is available here:
-https://github.com/opengeospatial/CityGML-3.0Encodings/blob/master/CityGML/Examples/Transportation/Basic%20examples/Road_over_Bridge_CityGML3.0_LOD2_with_CityObjectRelations.gml
+The GML file is available on the https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/resources/examples/Transportation/Basic%20examples/Road_over_Bridge_CityGML3.0_LOD2_with_CityObjectRelations.gml[CityGML 3.0 Encodings Github].
 
 //
 //[[linking-rules-3-section]]
@@ -342,8 +336,7 @@ image::images/Example_Intersection.png[align="center",width="70%"]
 
 In <<figure-example-intersection>>, two Roads (=top-level features) are shown that each have two Sections and one Intersection. The two Roads cross each other at the Intersection. Although the Intersection and, thus, also its geometry is shared by both Roads, it exists in reality only once; i.e., the Intersection is integral part of both Roads. In contrast to Requirement <<req_global_referencinggeometries4,/req/global/referencinggeometries4>>, this should not be expressed by duplicating the Intersection to represent it inline of both Roads and link the duplicates using CityObjectRelations. Instead, the Intersection should be represented inline as part of one Road (here: Road 2) and be referenced by the other Road (here: Road 3) using an XLink that references the ID of the Intersection feature. This type of feature link is similar to Requirement <<req_global_alternativeaggregations,/req/global/alternativeaggregations>>, where XLinks are used to relate features to alternative aggregations, with the difference that Road 3 cannot semantically be considered an alternative aggregation of the Intersection.
 
-The GML file is available here:
-https://github.com/opengeospatial/CityGML-3.0Encodings/blob/master/CityGML/Examples/Transportation/Basic%20examples/ParkingGarage_CityGML3.0_LOD2_with_CityObjectRelations_and_XLinks.gml
+The GML file is available on the https://github.com/opengeospatial/CityGML3.0-GML-Encoding/tree/main/resources/examples/Transportation/Basic%20examples/ParkingGarage_CityGML3.0_LOD2_with_CityObjectRelations_and_XLinks.gml[CityGML 3.0 Encodings Github].
 
 The two Roads and the Intersection from the GML file are illustrated in the object diagram in <<figure-uml-intersection>>. The XLink reference is highlighted in red.
 


### PR DESCRIPTION
I tested the links in the requirements section and everything looks ok apart from the links at:
* http://www.opengis.net/spec/CityGML-1/3.0/*
* http://www.opengis.net/spec/CityGML-2/3.0/*
* http://schemas.opengis.net/citygml/3.0/*

But this is normal (I believe) since these links won't be valid until after the standard has been validated and published.

I've also taken the liberty of updating most of the github facing links to this github instead of the old one. The only exception being a few links that point to documents in a the `xlinks-discussion` branch of the old repository which were not moved. [For example](https://github.com/opengeospatial/CityGML-3.0Encodings/tree/xlinks-discussion/CityGML/Examples/Building/XLink_examples/4_Cross-Top-Level-XLink)

If it makes sense I would be happy to copy those documents over to this repository and update those links as well in this PR, just let me know.