### PR TITLE
Update the PDF & HTML links

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -1,6 +1,6 @@
 # GML Encoding Standard for CityGML 3.0
 
-Draft versions of this standard are available as [PDF](https://github.com/opengeospatial/CityGML-3.0Encodings/blob/master/CityGML/21-006.pdf) and [HTML](https://github.com/opengeospatial/CityGML-3.0Encodings/blob/master/CityGML/21-006.html) documents.
+Draft versions of this standard are available as [PDF](https://github.com/opengeospatial/CityGML-3.0Encodings/blob/main/standard/21-006.pdf) and [HTML](https://github.com/opengeospatial/CityGML-3.0Encodings/blob/main/standard/21-006.html) documents.
 
 ## Content
 


### PR DESCRIPTION
So they at least point to the right files, even if the files can't be rendered in GitHub, just downloaded.